### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.8.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>Initially funded by 8uhr30</comments>
   <civix>

--- a/templates/CRM/Esr/Form/Task/Contact.tpl
+++ b/templates/CRM/Esr/Form/Task/Contact.tpl
@@ -15,18 +15,18 @@
 <h3>{ts domain="de.systopia.esr"}Parameters{/ts}</h3>
 
 <div class="crm-section">
-  <div class="label">{$form.exporter_class.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}Generator{/ts}", {literal}{"id":"id-exporter_class","file":"CRM\/Esr\/Form\/Task\/Contact"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.exporter_class.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}Generator{/ts}", {literal}{"id":"id-exporter_class","file":"CRM\/Esr\/Form\/Task\/Contact"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.exporter_class.html}</div>
   <div class="clear"></div>
 </div>
 
 <div class="crm-section">
-  <div class="label">{$form.amount.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}Amount{/ts}", {literal}{"id":"id-amount","file":"CRM\/Esr\/Form\/Task\/Contact"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.amount.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}Amount{/ts}", {literal}{"id":"id-amount","file":"CRM\/Esr\/Form\/Task\/Contact"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.amount.html}&nbsp;CHF</div>
   <div class="clear"></div>
 </div>
 <div class="crm-section">
-  <div class="label">{$form.tn_number.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}ESR Number{/ts}", {literal}{"id":"id-number","file":"CRM\/Esr\/Form\/Task\/Contact"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.tn_number.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}ESR Number{/ts}", {literal}{"id":"id-number","file":"CRM\/Esr\/Form\/Task\/Contact"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.tn_number.html}</div>
   <div class="clear"></div>
 </div>

--- a/templates/CRM/Esr/Form/Task/Membership.tpl
+++ b/templates/CRM/Esr/Form/Task/Membership.tpl
@@ -15,24 +15,24 @@
 <h3>{ts domain="de.systopia.esr"}Parameters{/ts}</h3>
 
 <div class="crm-section">
-  <div class="label">{$form.exporter_class.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}Generator{/ts}", {literal}{"id":"id-exporter_class","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.exporter_class.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}Generator{/ts}", {literal}{"id":"id-exporter_class","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.exporter_class.html}</div>
   <div class="clear"></div>
 </div>
 <div class="crm-section">
-  <div class="label">{$form.tn_number.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}ESR Registration{/ts}", {literal}{"id":"id-number","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.tn_number.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}ESR Registration{/ts}", {literal}{"id":"id-number","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.tn_number.html}</div>
   <div class="clear"></div>
 </div>
 
 <div class="crm-section">
-  <div class="label">{$form.paying_contact.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}Buyer Options{/ts}", {literal}{"id":"id-buyer","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.paying_contact.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}Buyer Options{/ts}", {literal}{"id":"id-buyer","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.paying_contact.html}</div>
   <div class="clear"></div>
 </div>
 
 <div class="crm-section">
-  <div class="label">{$form.amount_option.label} <a onclick='CRM.help("{ts domain="de.systopia.esr"}Amount Options{/ts}", {literal}{"id":"id-amount","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.amount_option.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.esr"}Amount Options{/ts}", {literal}{"id":"id-amount","file":"CRM\/Esr\/Form\/Task\/Membership"}{/literal}); return false;' href="#" title="Help" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.amount_option.html}</div>
   <div class="clear"></div>
 </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.