### PR TITLE
Add missing parameter in `\CRM_Esr_GeneratorQR::generateRecord()`

### DIFF
--- a/CRM/Esr/GeneratorQR.php
+++ b/CRM/Esr/GeneratorQR.php
@@ -447,7 +447,7 @@ class CRM_Esr_GeneratorQR extends CRM_Esr_Generator {
   /**
    * generate a new record on the next line of the query result
    */
-  protected function generateRecord($type, $query, $params) {
+  protected function generateRecord($type, $query, $params, $offset = 0) {
     $record = array();
 
     // basic information


### PR DESCRIPTION
`$offset` was used in the method `\CRM_Esr_GeneratorQR::generateRecord()`, but not defined. Because of the implicit casting the use in an addition resulted in a `0`.

There's no method call with four arguments so this modification doesn't result in a behavior change, but prevents a PHP warning.